### PR TITLE
[Feat] Implement the Diary CRUD

### DIFF
--- a/src/main/java/com/project/simsim_server/controller/DiaryController.java
+++ b/src/main/java/com/project/simsim_server/controller/DiaryController.java
@@ -1,0 +1,80 @@
+package com.project.simsim_server.controller;
+
+import com.project.simsim_server.dto.DiaryRequestDTO;
+import com.project.simsim_server.dto.DiaryResponseDTO;
+import com.project.simsim_server.service.DiaryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/diary")
+@RestController
+public class DiaryController {
+
+    private final DiaryService diaryService;
+
+    /**
+     * 유저가 특정 일기 하나만을 클릭하여 상세 내용을 조회
+     * @param diaryPk
+     * @return DiaryResponseDTO (하나의 일기의 상세 내용) / 데이터가 없는 경우 에러
+     */
+    @GetMapping("/{diaryPk}")
+    public DiaryResponseDTO findById(
+            @PathVariable Long diaryPk
+    ) {
+        return diaryService.findById(diaryPk);
+    }
+
+
+    /**
+     * 유저가 선택한 일자의 일기 내용 전체를 조회
+     * @param targetDate
+     * @return List<DiaryResponseDTO> / 데이터가 없는 경우 List의 길이가 0
+     */
+//    @GetMapping("/{targetDate}")
+//    public List<DiaryResponseDTO> findByCreatedDateAndUserEmail(
+//            @RequestParam String userEmail,
+//            @PathVariable LocalDateTime targetDate) {
+//        return diaryService.findByCreatedDateAndUserEmail(targetDate, userEmail);
+//    }
+
+
+    /**
+     * 유저가 작성한 하나의 일기를 DB에 저장
+     * @param diaryRequestDTO
+     * @return dairyResponseDTO / 데이터가 없는 경우 에러
+     */
+    @PostMapping("/save")
+    public DiaryResponseDTO save(
+            @RequestBody DiaryRequestDTO diaryRequestDTO
+    ) {
+        return diaryService.save(diaryRequestDTO);
+    }
+
+
+
+    /**
+     * 유저가 일기 상세 페이지에서 수정한 내용을 DB에 저장
+     * @param diaryPk
+     * @param diaryRequestDTO
+     * @return dairyResponseDTO / 데이터가 없는 경우 에러
+     */
+    @PatchMapping("/{diaryPk}")
+    public DiaryResponseDTO updateDiary(
+            @PathVariable Long diaryPk,
+            @RequestBody DiaryRequestDTO diaryRequestDTO
+    ) {
+        return diaryService.updateDiary(diaryPk, diaryRequestDTO);
+    }
+
+
+    /**
+     * 유저가 일기를 삭제(실제 데이터가 DB에서 삭제되는 것이 아니라 deleteYn의 값이 "N"으로 변경)
+     * @param diaryPk
+     */
+    @DeleteMapping("/{diaryPk}")
+    public void deleteDiary(@PathVariable Long diaryPk) {
+
+        diaryService.deleteDiary(diaryPk);
+    }
+}

--- a/src/main/java/com/project/simsim_server/domain/diary/Diary.java
+++ b/src/main/java/com/project/simsim_server/domain/diary/Diary.java
@@ -6,7 +6,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -27,16 +26,6 @@ public class Diary extends BaseTimeEntity {
     @Column(name = "diary_content", columnDefinition = "TEXT", length = 500)
     private String content;
 
-    @Column(name = "diary_emotion1")
-    private String emotion1;
-
-    @Column(name = "diary_emotion1_score")
-    @ColumnDefault("0")
-    private int emotion1Score;
-
-    @Column(name = "diary_ai_reply", columnDefinition = "TEXT", length = 500)
-    private String aiReply;
-
     @Column(name = "diary_list_key", nullable = false)
     private String listKey;
 
@@ -45,11 +34,20 @@ public class Diary extends BaseTimeEntity {
     private String diaryDeleteYn;
 
     @Builder
-    public Diary(String content, Long userPk) {
+    public Diary(Long userPk, String content) {
         LocalDateTime localDateTimeNow = LocalDateTime.now();
         this.content = content;
         this.userPk = userPk;
         this.listKey = userPk + "-" + localDateTimeNow.format(DateTimeFormatter.ofPattern("yyMMddHHmmss"));
         this.diaryDeleteYn = "N";
+    }
+
+    public Diary update(String content) {
+        this.content = content;
+        return this;
+    }
+
+    public void delete() {
+        this.diaryDeleteYn = "Y";
     }
 }

--- a/src/main/java/com/project/simsim_server/dto/DiaryRequestDTO.java
+++ b/src/main/java/com/project/simsim_server/dto/DiaryRequestDTO.java
@@ -1,0 +1,27 @@
+package com.project.simsim_server.dto;
+
+import com.project.simsim_server.domain.diary.Diary;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class DiaryRequestDTO {
+
+    private Long userPk;
+    private String content;
+
+    @Builder
+    public DiaryRequestDTO(Long userPk, String content) {
+        this.userPk = userPk;
+        this.content = content;
+    }
+
+    public Diary toEntity() {
+        return Diary.builder()
+                .userPk(userPk)
+                .content(content)
+                .build();
+    }
+}

--- a/src/main/java/com/project/simsim_server/dto/DiaryResponseDTO.java
+++ b/src/main/java/com/project/simsim_server/dto/DiaryResponseDTO.java
@@ -1,0 +1,28 @@
+package com.project.simsim_server.dto;
+
+import com.project.simsim_server.domain.diary.Diary;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class DiaryResponseDTO {
+
+    private Long diaryPk;
+    private Long userPk;
+    private String content;
+    private String deleteYn;
+    private LocalDateTime createdDate;
+    private LocalDateTime modifiedDate;
+
+    public DiaryResponseDTO(Diary diaryEntity) {
+        this.diaryPk = diaryEntity.getDiaryPk();
+        this.userPk = diaryEntity.getUserPk();
+        this.content = diaryEntity.getContent();
+        this.deleteYn = diaryEntity.getDiaryDeleteYn();
+        this.createdDate = diaryEntity.getCreatedDate();
+        this.modifiedDate = diaryEntity.getModifiedDate();
+    }
+}

--- a/src/main/java/com/project/simsim_server/repository/DiaryRepository.java
+++ b/src/main/java/com/project/simsim_server/repository/DiaryRepository.java
@@ -3,6 +3,10 @@ package com.project.simsim_server.repository;
 import com.project.simsim_server.domain.diary.Diary;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
+    public List<Diary> findDiariesByCreatedDateAndUserPk(LocalDateTime createdDate, Long UserPk);
 }

--- a/src/main/java/com/project/simsim_server/service/DiaryService.java
+++ b/src/main/java/com/project/simsim_server/service/DiaryService.java
@@ -1,0 +1,60 @@
+package com.project.simsim_server.service;
+
+import com.project.simsim_server.domain.diary.Diary;
+import com.project.simsim_server.dto.DiaryRequestDTO;
+import com.project.simsim_server.dto.DiaryResponseDTO;
+import com.project.simsim_server.repository.DiaryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class DiaryService {
+
+    private final DiaryRepository diaryRepository;
+
+    public DiaryResponseDTO findById(Long diaryPk) {
+        Diary result = diaryRepository.findById(diaryPk)
+                .orElseThrow(() ->
+                        new IllegalArgumentException("해당 일기가 존재하지 않습니다. 일기번호 : " + diaryPk));
+        return new DiaryResponseDTO(result);
+    }
+
+
+//    //TODO - UserEntity 생성 후 수정
+//    public List<DiaryResponseDTO> findByCreatedDateAndUserEmail(
+//            LocalDateTime targetDate,
+//            String userEmail
+//    ) {
+//        User user = userRepository.findByEmail(userEmail);
+//        List<Diary> diaries = diaryRepository
+//                .findDiariesByCreatedDateAndUserPk(targetDate, userPk);
+//        return diaries.stream()
+//                .map(DiaryResponseDTO::new)
+//                .collect(Collectors.toCollection(ArrayList::new));
+//    }
+
+
+    public DiaryResponseDTO save(DiaryRequestDTO diaryRequestDTO) {
+        return new DiaryResponseDTO(diaryRepository.save(diaryRequestDTO.toEntity()));
+    }
+
+    @Transactional
+    public DiaryResponseDTO updateDiary(Long diaryPk, DiaryRequestDTO diaryRequestDTO) {
+        Diary result = diaryRepository.findById(diaryPk)
+                .orElseThrow(() ->
+                        new IllegalArgumentException("해당 일기가 존재하지 않습니다. 일기번호 : " + diaryPk));
+
+        Diary updateDiary = result.update(diaryRequestDTO.getContent());
+        return new DiaryResponseDTO(updateDiary);
+    }
+
+    @Transactional
+    public void deleteDiary(Long diaryPk) {
+        Diary result = diaryRepository.findById(diaryPk)
+                .orElseThrow(() ->
+                        new IllegalArgumentException("해당 일기가 존재하지 않습니다. 일기번호 : " + diaryPk));
+        result.delete();
+    }
+}

--- a/src/main/sql/ddl.sql
+++ b/src/main/sql/ddl.sql
@@ -1,0 +1,11 @@
+drop table if exists diary;
+create table diary (
+       diary_pk bigint not null auto_increment,
+       user_pk bigint not null,
+       diary_content varchar(500),
+       diary_list_key varchar(30) not null,
+       diary_delete_yn char(1) default 'N' not null,
+       created_date datetime(6) not null,
+       modified_date datetime(6) not null,
+       primary key (diary_pk)
+);

--- a/src/test/java/com/project/simsim_server/controller/DiaryControllerTest.java
+++ b/src/test/java/com/project/simsim_server/controller/DiaryControllerTest.java
@@ -1,0 +1,119 @@
+package com.project.simsim_server.controller;
+
+import com.project.simsim_server.domain.diary.Diary;
+import com.project.simsim_server.dto.DiaryRequestDTO;
+import com.project.simsim_server.dto.DiaryResponseDTO;
+import com.project.simsim_server.repository.DiaryRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+/**
+ * 일기 수정 테스트는 Postman과 DBeaver로 확인
+ * (PATCH Request를 보내는 방법 확인 중)
+ */
+@SpringBootTest(webEnvironment= SpringBootTest.WebEnvironment.RANDOM_PORT)
+class DiaryControllerTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate testTemplate;
+
+    @Autowired
+    private DiaryRepository diaryRepository;
+
+    @AfterEach
+    public void cleanUp() {
+        diaryRepository.deleteAll();
+    }
+
+
+
+    /**
+     * 테스트용 다이어리 샘플 등록 함수
+     * @return ResponseEntity<DiaryResponseDTO> 일기 저장 후 HTTP 응답 정보
+     */
+    private ResponseEntity<DiaryResponseDTO> makeTestDiarySample() {
+        Long userPK = 8L;
+        String content = "DiaryController Test!";
+        String url = "http://localhost:" + port + "/api/v1/diary/save";
+
+        DiaryRequestDTO diaryRequestDTO = DiaryRequestDTO.builder()
+                .userPk(userPK)
+                .content(content)
+                .build();
+
+        return testTemplate.postForEntity(url, diaryRequestDTO, DiaryResponseDTO.class);
+    }
+
+    @Test
+    public void 일기_저장() {
+        //given
+        ResponseEntity<DiaryResponseDTO> sample = makeTestDiarySample();
+
+        //then
+        assertThat(sample.getStatusCode())
+                .isEqualTo(HttpStatus.OK);
+        assertThat(Objects.requireNonNull(sample.getBody())
+                .getDiaryPk()).isPositive();
+
+        List<Diary> diaries = diaryRepository.findAll();
+        assertThat(diaries.getFirst().getUserPk())
+                .isEqualTo(sample.getBody().getUserPk());
+        assertThat(diaries.getFirst().getContent())
+                .isEqualTo(sample.getBody().getContent());
+    }
+
+    @Test
+    public void 특정일기_가져오기() {
+        //given
+        ResponseEntity<DiaryResponseDTO> sample = makeTestDiarySample();
+
+        //when
+        Long diaryPk = Objects.requireNonNull(sample.getBody())
+                .getDiaryPk();
+        String url2 = "http://localhost:" + port + "/api/v1/diary/"
+                + diaryPk;
+        ResponseEntity<DiaryResponseDTO> getResponseEntity =
+                testTemplate.getForEntity(url2, DiaryResponseDTO.class);
+
+        //then
+        assertThat(getResponseEntity.getStatusCode())
+                .isEqualTo(HttpStatus.OK);
+        assertThat(Objects.requireNonNull(getResponseEntity.getBody())
+                .getContent()).isEqualTo(sample.getBody().getContent());
+
+    }
+
+    @Test
+    public void 일기_삭제() {
+        //given
+        ResponseEntity<DiaryResponseDTO> sample = makeTestDiarySample();
+
+        //when
+        Long diaryPk = Objects.requireNonNull(sample.getBody()).getDiaryPk();
+        String url2 = "http://localhost:" + port + "/api/v1/diary/" + diaryPk;
+        testTemplate.delete(url2);
+
+        //then
+        assertThat(sample.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        String url3 = "http://localhost:" + port + "/api/v1/diary/" + diaryPk;
+        ResponseEntity<DiaryResponseDTO> getResponseEntity =
+                testTemplate.getForEntity(url3, DiaryResponseDTO.class);
+        assertThat(Objects.requireNonNull(getResponseEntity.getBody()).getDeleteYn()).isEqualTo("Y");
+    }
+}


### PR DESCRIPTION
**작업 내용**
---
- Diary 엔티티 생성
- Diary Request/Response DTO 생성
- Diary CRUD API 생성
- Diary CRUD 테스트

**기타 사항**
---
### 할 일
- UserPk/UserEmail 와 같은 회원 정보 저장 방법 및 타겟 일자 전달 형식 결정 후, 조회/등록/수정 요청에 반영하여 수정하기