### PR TITLE
[Fix] Fixed Diary API Methods

### DIFF
--- a/src/main/java/com/project/simsim_server/controller/diary/DiaryController.java
+++ b/src/main/java/com/project/simsim_server/controller/diary/DiaryController.java
@@ -1,43 +1,53 @@
 package com.project.simsim_server.controller.diary;
 
+import com.project.simsim_server.dto.diary.DiaryCountResponseDTO;
 import com.project.simsim_server.dto.diary.DiaryRequestDTO;
 import com.project.simsim_server.dto.diary.DiaryResponseDTO;
 import com.project.simsim_server.service.diary.DiaryService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
 
 @RequiredArgsConstructor
-@CrossOrigin(origins = "*") //TODO - 테스트용, 추후 제거
 @RequestMapping("/api/v1/diary")
+@CrossOrigin(origins = "*")
 @RestController
 public class DiaryController {
 
     private final DiaryService diaryService;
 
     /**
-     * 유저가 특정 일기 하나만을 클릭하여 상세 내용을 조회
-     * @param diaryId
-     * @return DiaryResponseDTO (하나의 일기의 상세 내용) / 데이터가 없는 경우 에러
-     */
-    @GetMapping("/{diaryId}")
-    public DiaryResponseDTO findById(
-            @PathVariable Long diaryId
-    ) {
-        return diaryService.findById(diaryId);
-    }
-
-
-    /**
      * 유저가 선택한 일자의 일기 내용 전체를 조회
      * @param targetDate
      * @return List<DiaryResponseDTO> / 데이터가 없는 경우 List의 길이가 0
      */
-//    @GetMapping("/{targetDate}")
-//    public List<DiaryResponseDTO> findByCreatedDateAndUserEmail(
-//            @RequestParam String userEmail,
-//            @PathVariable LocalDateTime targetDate) {
-//        return diaryService.findByCreatedDateAndUserEmail(targetDate, userEmail);
-//    }
+    @GetMapping("/{targetDate}")
+    public List<DiaryResponseDTO> findByCreatedDate(
+            @PathVariable LocalDate targetDate) {
+        return diaryService.findByCreatedDate(targetDate);
+    }
+
+
+    /**
+     * 유저가 선택한 연도,월에 대해 일자별 일기 갯수 조회
+     * @param year
+     * @param month
+     * @return
+     */
+    @GetMapping("/{year}/{month}")
+    public List<DiaryCountResponseDTO> countByCreatedYearMonth(
+            @PathVariable String year,
+            @PathVariable String month
+    ) {
+        return diaryService.countDiariesByDate(year, month);
+    }
 
 
     /**
@@ -65,7 +75,11 @@ public class DiaryController {
             @PathVariable Long diaryId,
             @RequestBody DiaryRequestDTO diaryRequestDTO
     ) {
-        return diaryService.update(diaryId, diaryRequestDTO);
+        try {
+            return diaryService.update(diaryId, diaryRequestDTO);
+        } catch (Exception e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
+        }
     }
 
 
@@ -75,7 +89,6 @@ public class DiaryController {
      */
     @DeleteMapping("/{diaryId}")
     public void deleteDiary(@PathVariable Long diaryId) {
-
         diaryService.delete(diaryId);
     }
 }

--- a/src/main/java/com/project/simsim_server/domain/BaseTimeEntity.java
+++ b/src/main/java/com/project/simsim_server/domain/BaseTimeEntity.java
@@ -17,9 +17,11 @@ import java.time.LocalDateTime;
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseTimeEntity {
 
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @CreatedDate
     private LocalDateTime createdDate;
 
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @LastModifiedDate
     private LocalDateTime modifiedDate;
 

--- a/src/main/java/com/project/simsim_server/domain/diary/Diary.java
+++ b/src/main/java/com/project/simsim_server/domain/diary/Diary.java
@@ -1,11 +1,11 @@
 package com.project.simsim_server.domain.diary;
 
-import com.project.simsim_server.domain.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
+import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -14,7 +14,7 @@ import java.time.format.DateTimeFormatter;
 @NoArgsConstructor
 @Table(name = "diary_tbl")
 @Entity
-public class Diary extends BaseTimeEntity {
+public class Diary {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -34,17 +34,27 @@ public class Diary extends BaseTimeEntity {
     @ColumnDefault("'N'")
     private String diaryDeleteYn;
 
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @Column(name = "created_date", nullable = false)
+    private LocalDateTime createdDate;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @Column(name = "modified_date", nullable = false)
+    private LocalDateTime modifiedDate;
+
     @Builder
-    public Diary(Long userId, String content) {
-        LocalDateTime localDateTimeNow = LocalDateTime.now();
+    public Diary(Long userId, String content, LocalDateTime createdDate, LocalDateTime modifiedDate) {
         this.content = content;
         this.userId = userId;
-        this.listKey = userId + "-" + localDateTimeNow.format(DateTimeFormatter.ofPattern("yyMMddHHmmss"));
+        this.listKey = userId + "-" + createdDate.format(DateTimeFormatter.ofPattern("yyMMddHHmmss"));
         this.diaryDeleteYn = "N";
+        this.createdDate = createdDate;
+        this.modifiedDate = modifiedDate;
     }
 
-    public Diary update(String content) {
+    public Diary update(String content, LocalDateTime modifiedDate) {
         this.content = content;
+        this.modifiedDate = modifiedDate;
         return this;
     }
 
@@ -52,3 +62,4 @@ public class Diary extends BaseTimeEntity {
         this.diaryDeleteYn = "Y";
     }
 }
+

--- a/src/main/java/com/project/simsim_server/domain/user/Grade.java
+++ b/src/main/java/com/project/simsim_server/domain/user/Grade.java
@@ -1,0 +1,14 @@
+package com.project.simsim_server.domain.user;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Grade {
+    GENERAL("GENERAL", "일반"),
+    PREMIUM("PREMIUM", "프리미엄");
+
+    private final String key;
+    private final String title;
+}

--- a/src/main/java/com/project/simsim_server/domain/user/Role.java
+++ b/src/main/java/com/project/simsim_server/domain/user/Role.java
@@ -1,0 +1,15 @@
+package com.project.simsim_server.domain.user;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+    GUEST("ROLE_GUEST", "손님"),
+    USER("ROLE_USER", "일반 사용자"),
+    ADMIN("ROLE_ADMIN", "관리자");
+
+    private final String key;
+    private final String title;
+}

--- a/src/main/java/com/project/simsim_server/domain/user/Users.java
+++ b/src/main/java/com/project/simsim_server/domain/user/Users.java
@@ -1,0 +1,88 @@
+package com.project.simsim_server.domain.user;
+
+import com.project.simsim_server.domain.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+
+import java.nio.charset.StandardCharsets;
+
+@Getter
+@NoArgsConstructor
+@Table(name = "users_tbl")
+@Entity
+public class Users extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "user_name", nullable = false)
+    private String name;
+
+    @Column(name = "user_email", nullable = false)
+    private String email;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "user_role", nullable = false)
+    private Role role;
+
+    @Column(name = "user_grade", nullable = false)
+    @ColumnDefault("0")
+    private Grade grade;
+
+    @Column(name = "user_piece_cnt", nullable = false)
+    @ColumnDefault("0")
+    private int pieceCnt;
+
+    @Column(name = "user_persona", nullable = false)
+    @ColumnDefault("'P'")
+    private String persona;
+
+    @Column(name = "user_bg_image")
+    private String bgImage;
+
+    @Column(name = "user_status", nullable = false)
+    @ColumnDefault("'Y'")
+    private String userStatus;
+
+    @Builder
+    public Users(String name, String email, Role role) {
+        byte[] bytes = name.getBytes(StandardCharsets.ISO_8859_1);
+        this.name = new String(bytes, StandardCharsets.UTF_8);
+        this.email = email;
+        this.role = role;
+        this.grade = Grade.GENERAL;
+        this.pieceCnt = 0;
+        this.persona = "P";
+        this.userStatus = "Y";
+    }
+
+    public Users update(String name) {
+        byte[] bytes = name.getBytes(StandardCharsets.ISO_8859_1);
+        this.name = new String(bytes, StandardCharsets.UTF_8);
+        return this;
+    }
+
+    public Users updateGrade(Grade grade) {
+        this.grade = grade;
+        return this;
+    }
+
+    public Users delete() {
+        this.userStatus = "N";
+        return this;
+    }
+
+    public Users updatePuzzle(int cnt) {
+        this.pieceCnt = cnt;
+        return this;
+    }
+
+    public String getRoleKey() {
+        return this.role.getKey();
+    }
+}
+

--- a/src/main/java/com/project/simsim_server/dto/diary/DiaryCountResponseDTO.java
+++ b/src/main/java/com/project/simsim_server/dto/diary/DiaryCountResponseDTO.java
@@ -1,0 +1,20 @@
+package com.project.simsim_server.dto.diary;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@RequiredArgsConstructor
+public class DiaryCountResponseDTO {
+
+    private LocalDate markedDate;
+    private Long diaryCount;
+
+    public DiaryCountResponseDTO(LocalDateTime targetDate, Long diaryCount) {
+        this.markedDate = targetDate.toLocalDate();
+        this.diaryCount = diaryCount;
+    }
+}

--- a/src/main/java/com/project/simsim_server/dto/diary/DiaryRequestDTO.java
+++ b/src/main/java/com/project/simsim_server/dto/diary/DiaryRequestDTO.java
@@ -4,6 +4,11 @@ import com.project.simsim_server.domain.diary.Diary;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 
 @Getter
 @NoArgsConstructor
@@ -11,17 +16,25 @@ public class DiaryRequestDTO {
 
     private Long userId;
     private String content;
+    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'")
+    private LocalDateTime createdDate;
+    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'")
+    private LocalDateTime modifiedDate;
 
     @Builder
-    public DiaryRequestDTO(Long userId, String content) {
+    public DiaryRequestDTO(Long userId, String content, LocalDateTime createdDate, LocalDateTime modifiedDate) {
         this.userId = userId;
         this.content = content;
+        this.createdDate = createdDate;
+        this.modifiedDate = modifiedDate;
     }
 
     public Diary toEntity() {
         return Diary.builder()
                 .userId(userId)
                 .content(content)
+                .createdDate(ZonedDateTime.of(createdDate, ZoneId.of("UTC")).withZoneSameInstant(ZoneId.systemDefault()).toLocalDateTime())
+                .modifiedDate(ZonedDateTime.of(modifiedDate, ZoneId.of("UTC")).withZoneSameInstant(ZoneId.systemDefault()).toLocalDateTime())
                 .build();
     }
 }

--- a/src/main/java/com/project/simsim_server/exception/DiaryLimitExceededException.java
+++ b/src/main/java/com/project/simsim_server/exception/DiaryLimitExceededException.java
@@ -1,0 +1,7 @@
+package com.project.simsim_server.exception;
+
+public class DiaryLimitExceededException extends RuntimeException {
+    public DiaryLimitExceededException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/project/simsim_server/repository/diary/DiaryRepository.java
+++ b/src/main/java/com/project/simsim_server/repository/diary/DiaryRepository.java
@@ -12,10 +12,22 @@ import java.util.List;
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
     public List<Diary> findDiariesByCreatedDateAndUserId(LocalDateTime createdDate, Long userId);
 
-    @Query("SELECT d FROM Diary d WHERE d.userId = :userId AND d.createdDate >= :startDate AND d.createdDate < :endDate")
-    List<Diary>
-    findDiariesByCreatedAtBetweenAndUserId(
+    @Query("SELECT d FROM Diary d WHERE d.userId = :userId " +
+            "AND d.diaryDeleteYn = 'N'" +
+            "AND d.createdDate >= :startDate AND d.createdDate < :endDate")
+    List<Diary> findDiariesByCreatedAtBetweenAndUserId(
             @Param("startDate") LocalDateTime startDate,
             @Param("endDate") LocalDateTime endDate,
             @Param("userId") Long userId);
+
+    @Query("SELECT d.createdDate, COUNT(*) FROM Diary d " +
+            "WHERE d.userId = :userId " +
+            "AND d.diaryDeleteYn = 'N' " +
+            "AND d.createdDate BETWEEN :startDate AND :endDate " +
+            "GROUP BY d.createdDate")
+    List<Object[]> countDiariesByDate(
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate,
+            @Param("userId") Long userId
+    );
 }

--- a/src/main/java/com/project/simsim_server/repository/user/UsersRepository.java
+++ b/src/main/java/com/project/simsim_server/repository/user/UsersRepository.java
@@ -1,0 +1,12 @@
+package com.project.simsim_server.repository.user;
+
+import com.project.simsim_server.domain.user.Users;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UsersRepository extends JpaRepository<Users, Long> {
+    Optional<Users> findByEmail(String email);
+
+    Users findByName(String username);
+}

--- a/src/main/java/com/project/simsim_server/service/diary/DiaryService.java
+++ b/src/main/java/com/project/simsim_server/service/diary/DiaryService.java
@@ -1,29 +1,49 @@
 package com.project.simsim_server.service.diary;
 
 import com.project.simsim_server.domain.diary.Diary;
+import com.project.simsim_server.dto.diary.DiaryCountResponseDTO;
 import com.project.simsim_server.dto.diary.DiaryRequestDTO;
 import com.project.simsim_server.dto.diary.DiaryResponseDTO;
+import com.project.simsim_server.exception.DiaryLimitExceededException;
 import com.project.simsim_server.repository.diary.DiaryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.YearMonth;
+import java.util.List;
 
 @RequiredArgsConstructor
 @Service
 public class DiaryService {
 
     private final DiaryRepository diaryRepository;
+    private static final int MAX_DIARIES_PER_DAY = 3;
 
-    //TODO - 구현 후 처리
-    //    private final UserRepository userRepository; : 유저유무 체크하는 로직 모두 추가
-
-    public DiaryResponseDTO findById(Long diaryId) {
-        Diary result = diaryRepository.findById(diaryId)
-                .orElseThrow(() ->
-                        new IllegalArgumentException("해당 일기가 존재하지 않습니다. 일기번호 : " + diaryId));
-        return new DiaryResponseDTO(result);
+    public List<DiaryResponseDTO> findByCreatedDate(LocalDate targetDate) {
+        LocalDateTime startDate = targetDate.atStartOfDay();
+        LocalDateTime endDate = targetDate.atTime(LocalTime.MAX);
+        List<Diary> diaries = diaryRepository
+                .findDiariesByCreatedAtBetweenAndUserId(startDate, endDate, 1L);
+        return diaries.stream()
+                .map(DiaryResponseDTO::new)
+                .toList();
     }
 
+    public List<DiaryCountResponseDTO> countDiariesByDate(String year, String month) {
+        YearMonth yearMonth = YearMonth.of(Integer.parseInt(year), Integer.parseInt(month));
+        LocalDateTime startDate = yearMonth.atDay(1).atStartOfDay();
+        LocalDateTime endDate = yearMonth.atEndOfMonth().atTime(LocalTime.MAX);
+
+        List<Object[]> results = diaryRepository.countDiariesByDate(startDate, endDate, 1L);
+        return results.stream()
+                .map(result ->
+                        new DiaryCountResponseDTO((LocalDateTime) result[0], (Long) result[1]))
+                .toList();
+    }
 
 //    //TODO - UserEntity 생성 후 수정
 //    public List<DiaryResponseDTO> findByCreatedDateAndUserEmail(
@@ -40,6 +60,10 @@ public class DiaryService {
 
 
     public DiaryResponseDTO save(DiaryRequestDTO diaryRequestDTO) {
+        List<DiaryResponseDTO> todayDiaries = findByCreatedDate(LocalDate.now());
+        if (todayDiaries.size() == MAX_DIARIES_PER_DAY) {
+            throw new DiaryLimitExceededException("금일 작성할 수 있는 일기 갯수를 초과했습니다.");
+        }
         return new DiaryResponseDTO(diaryRepository.save(diaryRequestDTO.toEntity()));
     }
 
@@ -49,7 +73,17 @@ public class DiaryService {
                 .orElseThrow(() ->
                         new IllegalArgumentException("해당 일기가 존재하지 않습니다. 일기번호 : " + diaryId));
 
-        Diary updateDiary = result.update(diaryRequestDTO.getContent());
+        if (diaryRequestDTO.getUserId() == null || diaryRequestDTO.getUserId() < 0) {
+            throw new IllegalArgumentException("존재하지 않는 회원입니다.");
+        } else if (diaryRequestDTO.getCreatedDate() == null) {
+            throw new IllegalArgumentException("일기 등록 일자를 입력해 주세요.");
+        } else if (diaryRequestDTO.getModifiedDate() == null) {
+            throw new IllegalArgumentException("일기 수정 일자를 입력해 주세요.");
+        } else if (diaryRequestDTO.getCreatedDate().isAfter(LocalDateTime.now())
+                || diaryRequestDTO.getModifiedDate().isAfter(LocalDateTime.now())) {
+            throw new IllegalArgumentException("유효하지 않은 날짜입니다.");
+        }
+        Diary updateDiary = result.update(diaryRequestDTO.getContent(), diaryRequestDTO.getModifiedDate());
         return new DiaryResponseDTO(updateDiary);
     }
 


### PR DESCRIPTION
**작업 내용**
---
- Diary 등록 / 수정 시 서버가 아닌 프론트에서 일자 및 시간을 받아오도록 수정
- Diary 사용자가 지정한 연도/월의 정보를 받아 일자별 일기 개수를 반환하는 API 추가(한달 간의 일기 갯수 색깔 농도 표시용)