### PR TITLE
[Fix] Modified UserRepository Method and Set the TimeZone

### DIFF
--- a/src/main/java/com/project/simsim_server/SimsimServerApplication.java
+++ b/src/main/java/com/project/simsim_server/SimsimServerApplication.java
@@ -1,13 +1,20 @@
 package com.project.simsim_server;
 
+import jakarta.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import java.util.TimeZone;
 
 @EnableJpaAuditing
 @SpringBootApplication
 public class SimsimServerApplication {
 
+	@PostConstruct
+	void started(){
+		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+	}
 	public static void main(String[] args) {
 		SpringApplication.run(SimsimServerApplication.class, args);
 	}

--- a/src/main/java/com/project/simsim_server/config/auth/jwt/JwtUtils.java
+++ b/src/main/java/com/project/simsim_server/config/auth/jwt/JwtUtils.java
@@ -165,15 +165,7 @@ public class JwtUtils {
         Claims claims = parseClaims(token);
         List<SimpleGrantedAuthority> authorities = getAuthorities(claims);
         User principal = new User(claims.getSubject(), "", authorities);
-
-        log.warn("-----------[SimsimFilter] JwtUtils List<SimpleGrantedAuthority> authorities: {}", authorities);
-        log.warn("-----------[SimsimFilter] JwtUtils Authentication getAuthentication principal: {}", principal);
-
         return new UsernamePasswordAuthenticationToken(principal, token, authorities);
-//        JwtPayloadDTO jwtPayloadDTO = getUserInfo(token);
-//        List<GrantedAuthority> authorities = Collections.singletonList(new SimpleGrantedAuthority(jwtPayloadDTO.getUserRole().name()));
-//        CustomUserDetails userDetails = (CustomUserDetails) customUserDetailsService.loadUserByUsername(jwtPayloadDTO.getUserId().toString());
-//        return new UsernamePasswordAuthenticationToken(userDetails.getUser().getUserId(), null, authorities);
     }
 
 
@@ -185,17 +177,13 @@ public class JwtUtils {
 
     public String getEmail(String accessToken) {
         Claims claims = parseClaims(accessToken);
-        log.warn("디코딩 토큰: {}", claims.get("email", String.class));
         return claims.get("email", String.class);
 
     }
 
     public String getUserId(String accessToken) {
-
-        log.warn("토큰에서 유저정보 가져오기 대상 토큰 : {}", accessToken);
         Claims claims = parseClaims(accessToken);
         log.warn("디코딩 토큰: {}", claims.get("id", Long.class));
-
         return claims.get("id", Long.class).toString() ;
     }
 

--- a/src/main/java/com/project/simsim_server/controller/user/AuthController.java
+++ b/src/main/java/com/project/simsim_server/controller/user/AuthController.java
@@ -56,8 +56,7 @@ public class AuthController {
      * @return
      */
     @DeleteMapping("/logout")
-    public ResponseEntity logout(@RequestHeader("Authorization") String accessToken,
-                                 @AuthenticationPrincipal UserDetails userDetails) {
+    public ResponseEntity logout(@RequestHeader("Authorization") String accessToken) {
         String authentication = getUserIdFromAuthentication();
         Long userId = Long.parseLong(authentication);
         authService.logout(accessToken, userId);
@@ -80,11 +79,6 @@ public class AuthController {
     @DeleteMapping("/delete")
     public ResponseEntity cancleAccount(@RequestHeader("Authorization") String accessToken) {
         String authentication = getUserIdFromAuthentication();
-        if (authentication.equals("-1")) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Unauthorized - No authentication information found");
-        } else if (authentication.equals("-2")) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Unauthorized - Anonymous user");
-        }
         Long userId = Long.parseLong(authentication);
         authService.delete(accessToken, userId);
         ResponseCookie responseCookie = ResponseCookie.from("refresh", "")
@@ -139,16 +133,6 @@ public class AuthController {
 
     private String getUserIdFromAuthentication() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null) {
-            // 인증 정보가 없는 경우 로깅
-            return "-1";
-        }
-
-        if (authentication.getPrincipal() instanceof String && authentication.getPrincipal().equals("anonymousUser")) {
-            // anonymousUser인 경우 처리 로직 추가 (필요 시)
-            return "-2";
-        }
-
         return authentication.getName();
     }
 }

--- a/src/main/java/com/project/simsim_server/controller/user/UsersController.java
+++ b/src/main/java/com/project/simsim_server/controller/user/UsersController.java
@@ -22,8 +22,8 @@ public class UsersController {
      * 회원 정보 조회
      * @return UserInfoResponseDTO 회원 정보
      */
-    @GetMapping("/me/{num}")
-    public UserInfoResponseDTO getUserInfo(@PathVariable int num) {
+    @GetMapping("/me")
+    public UserInfoResponseDTO getUserInfo() {
         String authentication = getUserIdFromAuthentication();
         log.warn("-------조회된 인증 객체 정보: {}", authentication);
         Long userId = Long.parseLong(authentication);

--- a/src/main/java/com/project/simsim_server/repository/user/PersonaRepository.java
+++ b/src/main/java/com/project/simsim_server/repository/user/PersonaRepository.java
@@ -1,4 +1,4 @@
-package com.project.simsim_server.repository.setting;
+package com.project.simsim_server.repository.user;
 
 import com.project.simsim_server.domain.user.Persona;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/project/simsim_server/repository/user/UsersRepository.java
+++ b/src/main/java/com/project/simsim_server/repository/user/UsersRepository.java
@@ -9,11 +9,9 @@ import java.util.Optional;
 
 public interface UsersRepository extends JpaRepository<Users, Long> {
 
-    Optional<Users> findByEmail(String email);
+    @Query("SELECT u FROM Users u WHERE u.email =:userEmail AND u.userStatus = 'Y'")
+    Optional<Users> findByEmailAAndUserStatus(@Param("userEmail") String userEmail);
 
     @Query("SELECT u FROM Users u WHERE u.userId =:userId AND u.userStatus = 'Y'")
     Optional<Users> findByIdAndUserStatus(@Param("userId") Long userId);
-
-    @Query("SELECT u FROM Users u WHERE u.userStatus = 'Y' AND u.email = :email")
-    Optional<Users> findByUserStatusAndEmail(@Param("email") String email);
 }

--- a/src/main/java/com/project/simsim_server/service/user/PersonaService.java
+++ b/src/main/java/com/project/simsim_server/service/user/PersonaService.java
@@ -2,7 +2,7 @@ package com.project.simsim_server.service.user;
 
 import com.project.simsim_server.domain.user.Persona;
 import com.project.simsim_server.dto.user.PersonaResponseDTO;
-import com.project.simsim_server.repository.setting.PersonaRepository;
+import com.project.simsim_server.repository.user.PersonaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/project/simsim_server/service/user/UsersService.java
+++ b/src/main/java/com/project/simsim_server/service/user/UsersService.java
@@ -9,7 +9,7 @@ import com.project.simsim_server.dto.user.UserInfoResponseDTO;
 import com.project.simsim_server.exception.ResourceNotFoundException;
 import com.project.simsim_server.exception.UserNotFoundException;
 import com.project.simsim_server.repository.diary.DiaryRepository;
-import com.project.simsim_server.repository.setting.PersonaRepository;
+import com.project.simsim_server.repository.user.PersonaRepository;
 import com.project.simsim_server.repository.user.UsersRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;


### PR DESCRIPTION
**작업 내용**
---
- UserRepository의 findByEmail()을 회원 정보 상태도 같이 조회할 수 있도록 findByEmailAndUserStatus()로 수정
- TimeZone을 서울로 세팅
- 회원정보를 조회하는 "/me" API에서 유저 정보를 받는 파라미터 삭제
- principal을 메일 -> 회원 식별번호로 변경

**기타 사항**
---
### 할 일
- 로그인이 한 번에 되지 않는 문제 처리