### PR TITLE
[Fix] 일기 수정 시간 로직 변경

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Build and Deploy
 on:
   push:
     branches:
-      - '*'
+      - main
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Build and Deploy
 on:
   push:
     branches:
-      - main
+      - '*'
 
 jobs:
   build-and-deploy:

--- a/src/main/java/com/project/simsim_server/dto/diary/DiaryRequestDTO.java
+++ b/src/main/java/com/project/simsim_server/dto/diary/DiaryRequestDTO.java
@@ -27,8 +27,10 @@ public class DiaryRequestDTO {
     @Builder
     public DiaryRequestDTO(String content, LocalDateTime createdDate, LocalDateTime modifiedDate) {
         this.content = content;
-        this.createdDate = ZonedDateTime.of(createdDate, ZoneId.of("UTC")).withZoneSameInstant(ZoneId.of("Asia/Seoul")).toLocalDateTime();
-        this.modifiedDate = ZonedDateTime.of(modifiedDate, ZoneId.of("UTC")).withZoneSameInstant(ZoneId.of("Asia/Seoul")).toLocalDateTime();
+//        this.createdDate = ZonedDateTime.of(createdDate, ZoneId.of("UTC")).withZoneSameInstant(ZoneId.of("Asia/Seoul")).toLocalDateTime();
+//        this.modifiedDate = ZonedDateTime.of(modifiedDate, ZoneId.of("UTC")).withZoneSameInstant(ZoneId.of("Asia/Seoul")).toLocalDateTime();
+        this.createdDate = createdDate;
+        this.modifiedDate = modifiedDate;
     }
 
     public Diary toEntity() {

--- a/src/main/java/com/project/simsim_server/dto/diary/DiaryRequestDTO.java
+++ b/src/main/java/com/project/simsim_server/dto/diary/DiaryRequestDTO.java
@@ -37,8 +37,8 @@ public class DiaryRequestDTO {
         return Diary.builder()
                 .userId(userId)
                 .content(content)
-                .createdDate(ZonedDateTime.of(createdDate, ZoneId.of("UTC")).withZoneSameInstant(ZoneId.of("Asia/Seoul")).toLocalDateTime())
-                .modifiedDate(ZonedDateTime.of(modifiedDate, ZoneId.of("UTC")).withZoneSameInstant(ZoneId.of("Asia/Seoul")).toLocalDateTime())
+                .createdDate(createdDate)
+                .modifiedDate(modifiedDate)
                 .build();
     }
 }

--- a/src/main/java/com/project/simsim_server/dto/diary/DiaryRequestDTO.java
+++ b/src/main/java/com/project/simsim_server/dto/diary/DiaryRequestDTO.java
@@ -27,10 +27,8 @@ public class DiaryRequestDTO {
     @Builder
     public DiaryRequestDTO(String content, LocalDateTime createdDate, LocalDateTime modifiedDate) {
         this.content = content;
-//        this.createdDate = ZonedDateTime.of(createdDate, ZoneId.of("UTC")).withZoneSameInstant(ZoneId.of("Asia/Seoul")).toLocalDateTime();
-//        this.modifiedDate = ZonedDateTime.of(modifiedDate, ZoneId.of("UTC")).withZoneSameInstant(ZoneId.of("Asia/Seoul")).toLocalDateTime();
-        this.createdDate = createdDate;
-        this.modifiedDate = modifiedDate;
+        this.createdDate = ZonedDateTime.of(createdDate, ZoneId.of("UTC")).toLocalDateTime();
+        this.modifiedDate = ZonedDateTime.of(modifiedDate, ZoneId.of("UTC")).toLocalDateTime();
     }
 
     public Diary toEntity() {

--- a/src/main/java/com/project/simsim_server/dto/diary/DiaryResponseDTO.java
+++ b/src/main/java/com/project/simsim_server/dto/diary/DiaryResponseDTO.java
@@ -45,7 +45,7 @@ public class DiaryResponseDTO {
         this.modifiedDate = convertToUTC(diaryEntity.getModifiedDate());
 
         log.info("------[SimSimInfo] Response 일기 생성 시각 : {} ----------------", this.createdDate);
-        log.info("------[SimSimInfo] Response 일기 삭제 시각 : {} ----------------", this.modifiedDate);
+        log.info("------[SimSimInfo] Response 일기 수정 시각 : {} ----------------", this.modifiedDate);
     }
 
     private String convertToUTC(LocalDateTime localDateTime) {

--- a/src/main/java/com/project/simsim_server/dto/diary/DiaryResponseDTO.java
+++ b/src/main/java/com/project/simsim_server/dto/diary/DiaryResponseDTO.java
@@ -42,6 +42,7 @@ public class DiaryResponseDTO {
         this.deleteYn = diaryEntity.getDiaryDeleteYn();
         this.markedDate = diaryEntity.getMarkedDate();
         this.createdDate = convertToUTC(diaryEntity.getCreatedDate());
+        this.modifiedDate = String.valueOf(diaryEntity.getModifiedDate());
 //        this.modifiedDate = convertToUTC(diaryEntity.getModifiedDate());
 
         log.info("------[SimSimInfo] Response 일기 생성 시각 : {} ----------------", this.createdDate);

--- a/src/main/java/com/project/simsim_server/dto/diary/DiaryResponseDTO.java
+++ b/src/main/java/com/project/simsim_server/dto/diary/DiaryResponseDTO.java
@@ -43,9 +43,6 @@ public class DiaryResponseDTO {
         this.markedDate = diaryEntity.getMarkedDate();
         this.createdDate = convertToKST(diaryEntity.getCreatedDate());
         this.modifiedDate = convertToKST(diaryEntity.getModifiedDate());
-
-        log.info("------[SimSimInfo] Response 일기 생성 시각 : {} ----------------", this.createdDate);
-        log.info("------[SimSimInfo] Response 일기 수정 시각 : {} ----------------", this.modifiedDate);
     }
 
     private String convertToKST(LocalDateTime utcDateTime) {

--- a/src/main/java/com/project/simsim_server/dto/diary/DiaryResponseDTO.java
+++ b/src/main/java/com/project/simsim_server/dto/diary/DiaryResponseDTO.java
@@ -43,6 +43,9 @@ public class DiaryResponseDTO {
         this.markedDate = diaryEntity.getMarkedDate();
         this.createdDate = convertToUTC(diaryEntity.getCreatedDate());
         this.modifiedDate = convertToUTC(diaryEntity.getModifiedDate());
+
+        log.info("------[SimSimInfo] Response 일기 생성 시각 : {} ----------------", this.createdDate);
+        log.info("------[SimSimInfo] Response 일기 삭제 시각 : {} ----------------", this.modifiedDate);
     }
 
     private String convertToUTC(LocalDateTime localDateTime) {

--- a/src/main/java/com/project/simsim_server/dto/diary/DiaryResponseDTO.java
+++ b/src/main/java/com/project/simsim_server/dto/diary/DiaryResponseDTO.java
@@ -42,8 +42,7 @@ public class DiaryResponseDTO {
         this.deleteYn = diaryEntity.getDiaryDeleteYn();
         this.markedDate = diaryEntity.getMarkedDate();
         this.createdDate = convertToUTC(diaryEntity.getCreatedDate());
-        this.modifiedDate = String.valueOf(diaryEntity.getModifiedDate());
-//        this.modifiedDate = convertToUTC(diaryEntity.getModifiedDate());
+        this.modifiedDate = convertToUTC(diaryEntity.getModifiedDate());
 
         log.info("------[SimSimInfo] Response 일기 생성 시각 : {} ----------------", this.createdDate);
         log.info("------[SimSimInfo] Response 일기 수정 시각 : {} ----------------", this.modifiedDate);

--- a/src/main/java/com/project/simsim_server/dto/diary/DiaryResponseDTO.java
+++ b/src/main/java/com/project/simsim_server/dto/diary/DiaryResponseDTO.java
@@ -49,6 +49,9 @@ public class DiaryResponseDTO {
     }
 
     private String convertToUTC(LocalDateTime localDateTime) {
+        if (ZoneId.systemDefault().equals(ZoneId.of("UTC"))) {
+            return localDateTime.format(DateTimeFormatter.ISO_INSTANT);
+        }
         ZonedDateTime zonedDateTime = ZonedDateTime.of(localDateTime, ZoneId.systemDefault()).withZoneSameInstant(ZoneId.of("UTC"));
         return zonedDateTime.format(DateTimeFormatter.ISO_INSTANT);
     }

--- a/src/main/java/com/project/simsim_server/dto/diary/DiaryResponseDTO.java
+++ b/src/main/java/com/project/simsim_server/dto/diary/DiaryResponseDTO.java
@@ -41,18 +41,16 @@ public class DiaryResponseDTO {
         }
         this.deleteYn = diaryEntity.getDiaryDeleteYn();
         this.markedDate = diaryEntity.getMarkedDate();
-        this.createdDate = convertToUTC(diaryEntity.getCreatedDate());
-        this.modifiedDate = convertToUTC(diaryEntity.getModifiedDate());
+        this.createdDate = convertToKST(diaryEntity.getCreatedDate());
+        this.modifiedDate = convertToKST(diaryEntity.getModifiedDate());
 
         log.info("------[SimSimInfo] Response 일기 생성 시각 : {} ----------------", this.createdDate);
         log.info("------[SimSimInfo] Response 일기 수정 시각 : {} ----------------", this.modifiedDate);
     }
 
-    private String convertToUTC(LocalDateTime localDateTime) {
-        if (ZoneId.systemDefault().equals(ZoneId.of("UTC"))) {
-            return localDateTime.format(DateTimeFormatter.ISO_INSTANT);
-        }
-        ZonedDateTime zonedDateTime = ZonedDateTime.of(localDateTime, ZoneId.systemDefault()).withZoneSameInstant(ZoneId.of("UTC"));
-        return zonedDateTime.format(DateTimeFormatter.ISO_INSTANT);
+    private String convertToKST(LocalDateTime utcDateTime) {
+        ZonedDateTime kstDateTime = ZonedDateTime.of(utcDateTime, ZoneId.of("UTC"))
+                .withZoneSameInstant(ZoneId.of("Asia/Seoul"));
+        return kstDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS"));
     }
 }

--- a/src/main/java/com/project/simsim_server/dto/diary/DiaryResponseDTO.java
+++ b/src/main/java/com/project/simsim_server/dto/diary/DiaryResponseDTO.java
@@ -42,7 +42,7 @@ public class DiaryResponseDTO {
         this.deleteYn = diaryEntity.getDiaryDeleteYn();
         this.markedDate = diaryEntity.getMarkedDate();
         this.createdDate = convertToUTC(diaryEntity.getCreatedDate());
-        this.modifiedDate = convertToUTC(diaryEntity.getModifiedDate());
+//        this.modifiedDate = convertToUTC(diaryEntity.getModifiedDate());
 
         log.info("------[SimSimInfo] Response 일기 생성 시각 : {} ----------------", this.createdDate);
         log.info("------[SimSimInfo] Response 일기 수정 시각 : {} ----------------", this.modifiedDate);

--- a/src/main/java/com/project/simsim_server/service/diary/DiaryService.java
+++ b/src/main/java/com/project/simsim_server/service/diary/DiaryService.java
@@ -123,8 +123,4 @@ public class DiaryService {
 
         log.info("------[SimSimInfo] 일기 삭제 시각 : {} ----------------", result.getModifiedDate());
     }
-
-    private LocalDate toLocalDate(LocalDateTime localDateTime, ZoneId zoneId) {
-        return localDateTime.atZone(zoneId).toLocalDate();
-    }
 }

--- a/src/main/java/com/project/simsim_server/service/diary/DiaryService.java
+++ b/src/main/java/com/project/simsim_server/service/diary/DiaryService.java
@@ -107,7 +107,7 @@ public class DiaryService {
         Diary result = diaryRepository.findByIdAndUserId(diaryId, userId)
                 .orElseThrow(() -> new DiaryException(DIARY_NOT_FOUND));
 
-        log.info("------[SimSimInfo] 일기 수정 시각 : {} {} ----------------", diaryRequestDTO.getModifiedDate(), toLocalDate(diaryRequestDTO.getModifiedDate(), ZoneId.of("KST")));
+        log.info("------[SimSimInfo] 일기 수정 시각 : {} ----------------", diaryRequestDTO.getModifiedDate());
 
         Diary updateDiary = result.update(diaryRequestDTO.getContent(), diaryRequestDTO.getModifiedDate());
         return new DiaryResponseDTO(updateDiary);

--- a/src/main/java/com/project/simsim_server/service/diary/DiaryService.java
+++ b/src/main/java/com/project/simsim_server/service/diary/DiaryService.java
@@ -107,6 +107,8 @@ public class DiaryService {
         Diary result = diaryRepository.findByIdAndUserId(diaryId, userId)
                 .orElseThrow(() -> new DiaryException(DIARY_NOT_FOUND));
 
+        log.info("------[SimSimInfo] 일기 수정 시각 : {} ----------------", diaryRequestDTO.getModifiedDate());
+
         Diary updateDiary = result.update(diaryRequestDTO.getContent(), diaryRequestDTO.getModifiedDate());
         return new DiaryResponseDTO(updateDiary);
     }
@@ -118,6 +120,8 @@ public class DiaryService {
                 .orElseThrow(() ->
                         new IllegalArgumentException("해당 일기가 존재하지 않습니다. 일기번호 : " + diaryId));
         result.delete();
+
+        log.info("------[SimSimInfo] 일기 삭제 시각 : {} ----------------", result.getModifiedDate());
     }
 
     private LocalDate toLocalDate(LocalDateTime localDateTime, ZoneId zoneId) {

--- a/src/main/java/com/project/simsim_server/service/diary/DiaryService.java
+++ b/src/main/java/com/project/simsim_server/service/diary/DiaryService.java
@@ -90,8 +90,6 @@ public class DiaryService {
         List<Diary> todayDiaries
                 = diaryRepository.findByCreatedAtAndUserId(userId, targetDate);
 
-
-
         if (todayDiaries.size() == MAX_DIARIES_PER_DAY) {
             log.error("---[SimSimInfo] 일기가 제한 갯수를 초과함 userId : {}, targetDate : {}",
                     userId, targetDate);
@@ -107,7 +105,7 @@ public class DiaryService {
         Diary result = diaryRepository.findByIdAndUserId(diaryId, userId)
                 .orElseThrow(() -> new DiaryException(DIARY_NOT_FOUND));
 
-        log.info("------[SimSimInfo] 일기 수정 시각 : {} ----------------", diaryRequestDTO.getModifiedDate());
+        log.info("---[SimSimInfo] 일기 수정 시각 : {} ---", diaryRequestDTO.getModifiedDate());
 
         Diary updateDiary = result.update(diaryRequestDTO.getContent(), diaryRequestDTO.getModifiedDate());
         return new DiaryResponseDTO(updateDiary);
@@ -121,6 +119,6 @@ public class DiaryService {
                         new IllegalArgumentException("해당 일기가 존재하지 않습니다. 일기번호 : " + diaryId));
         result.delete();
 
-        log.info("------[SimSimInfo] 일기 삭제 시각 : {} ----------------", result.getModifiedDate());
+        log.info("--- [SimSimInfo] 일기 삭제 시각 : {} ---", result.getModifiedDate());
     }
 }

--- a/src/main/java/com/project/simsim_server/service/diary/DiaryService.java
+++ b/src/main/java/com/project/simsim_server/service/diary/DiaryService.java
@@ -59,8 +59,6 @@ public class DiaryService {
             sendStatus = false;
         }
 
-        log.warn("!!!!!! sendStatus = {} !!!!!!", sendStatus);
-
         return DiaryDailyResponseDTO.builder()
                 .sendStatus(sendStatus)
                 .diaries(list)
@@ -84,9 +82,6 @@ public class DiaryService {
     public DiaryResponseDTO save(DiaryRequestDTO diaryRequestDTO, Long userId) {
         LocalDate targetDate = LocalDate.from(diaryRequestDTO.getCreatedDate().plusHours(9));
 
-        log.warn("들어온 날짜 : {}", diaryRequestDTO.getCreatedDate());
-        log.warn("조회 날짜 : {}", diaryRequestDTO.getCreatedDate().plusHours(9));
-
         List<Diary> todayDiaries
                 = diaryRepository.findByCreatedAtAndUserId(userId, targetDate);
 
@@ -105,8 +100,6 @@ public class DiaryService {
         Diary result = diaryRepository.findByIdAndUserId(diaryId, userId)
                 .orElseThrow(() -> new DiaryException(DIARY_NOT_FOUND));
 
-        log.info("---[SimSimInfo] 일기 수정 시각 : {} ---", diaryRequestDTO.getModifiedDate());
-
         Diary updateDiary = result.update(diaryRequestDTO.getContent(), diaryRequestDTO.getModifiedDate());
         return new DiaryResponseDTO(updateDiary);
     }
@@ -118,7 +111,5 @@ public class DiaryService {
                 .orElseThrow(() ->
                         new IllegalArgumentException("해당 일기가 존재하지 않습니다. 일기번호 : " + diaryId));
         result.delete();
-
-        log.info("--- [SimSimInfo] 일기 삭제 시각 : {} ---", result.getModifiedDate());
     }
 }

--- a/src/main/java/com/project/simsim_server/service/diary/DiaryService.java
+++ b/src/main/java/com/project/simsim_server/service/diary/DiaryService.java
@@ -107,7 +107,7 @@ public class DiaryService {
         Diary result = diaryRepository.findByIdAndUserId(diaryId, userId)
                 .orElseThrow(() -> new DiaryException(DIARY_NOT_FOUND));
 
-        log.info("------[SimSimInfo] 일기 수정 시각 : {} ----------------", diaryRequestDTO.getModifiedDate());
+        log.info("------[SimSimInfo] 일기 수정 시각 : {} {} ----------------", diaryRequestDTO.getModifiedDate(), toLocalDate(diaryRequestDTO.getModifiedDate(), ZoneId.of("KST")));
 
         Diary updateDiary = result.update(diaryRequestDTO.getContent(), diaryRequestDTO.getModifiedDate());
         return new DiaryResponseDTO(updateDiary);


### PR DESCRIPTION
### Summary
- 고도화 작업 내용에 '일기 수정이 발생한 경우 수정시간으로 표시' 기능이 추가됨에 따라 해당 로직 구현
- 기존에 createdDate, modifiedDate의 Timezone을 KST -> UTC로 변경

### Test
- 하단의 사진과 같이 현재 수정시각으로 변경 된 것을 확인완료
- 수정 전 / 수정 후
<img width="210" alt="image" src="https://github.com/user-attachments/assets/89e48b93-c7c1-4eb2-b64c-bd8b38c065ae">
<img width="220" alt="image" src="https://github.com/user-attachments/assets/5f716ad6-f5ee-46b9-a631-7c70374e2712">