### PR TITLE
[Feat] 관리자 기록/AI 응답 다운로드 API 구현

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Build and Deploy
 on:
   push:
     branches:
-      - main
+      - '*'
 
 jobs:
   build-and-deploy:

--- a/src/main/java/com/project/simsim_server/config/auth/SecurityConfig.java
+++ b/src/main/java/com/project/simsim_server/config/auth/SecurityConfig.java
@@ -63,7 +63,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests((request) -> request
                         .requestMatchers( "/api/v1/auth/apple", "/api/v1/auth/google", "/api/v1/auth/reissue",
                                 "/swagger-ui/**", "/v3/api-docs/**").permitAll()
-                        .requestMatchers("/api/v1/admin", "/api/v1/export/**").hasRole(Role.ADMIN.name())
+                        .requestMatchers("/api/v1/admin").hasRole(Role.ADMIN.name())
                         .requestMatchers(HttpMethod.POST,"/notice").hasRole(Role.ADMIN.name())
                         .requestMatchers(HttpMethod.PATCH,"/notice/{noticeId}").hasRole(Role.ADMIN.name())
                         .requestMatchers(HttpMethod.DELETE,"/notice/{noticeId}").hasRole(Role.ADMIN.name())

--- a/src/main/java/com/project/simsim_server/config/auth/SecurityConfig.java
+++ b/src/main/java/com/project/simsim_server/config/auth/SecurityConfig.java
@@ -63,7 +63,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests((request) -> request
                         .requestMatchers( "/api/v1/auth/apple", "/api/v1/auth/google", "/api/v1/auth/reissue",
                                 "/swagger-ui/**", "/v3/api-docs/**").permitAll()
-                        .requestMatchers("/admin").hasRole(Role.ADMIN.name())
+                        .requestMatchers("/api/v1/admin", "/api/v1/export/**").hasRole(Role.ADMIN.name())
                         .requestMatchers(HttpMethod.POST,"/notice").hasRole(Role.ADMIN.name())
                         .requestMatchers(HttpMethod.PATCH,"/notice/{noticeId}").hasRole(Role.ADMIN.name())
                         .requestMatchers(HttpMethod.DELETE,"/notice/{noticeId}").hasRole(Role.ADMIN.name())

--- a/src/main/java/com/project/simsim_server/controller/admin/ExportController.java
+++ b/src/main/java/com/project/simsim_server/controller/admin/ExportController.java
@@ -18,6 +18,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
 
 
 @Slf4j
@@ -31,7 +33,7 @@ public class ExportController {
     private final AuthenticationService authenticationService;
 
     @GetMapping("/diary")
-    public ResponseEntity<Resource> exportDiary() throws IOException {
+    public ResponseEntity<List<Map<String, Object>>> exportDiary() throws IOException {
         Long userId = authenticationService.getUserIdFromAuthentication();
         log.info("---[SimSimInfo] 유저 {} 일기 Export 요청 시작", userId);
 
@@ -39,30 +41,13 @@ public class ExportController {
         String directory = System.getProperty("java.io.tmpdir"); // 안전한 임시 디렉토리 사용
         String filePath = directory + File.separator + fileName;
 
-        exportService.getDiaries(userId, filePath);
-        File file = new File(filePath);
-        if (!file.exists()) {
-            log.error("--- [SimSimError] exportDiary() 해당 파일이 존재하지 않습니다 {}", filePath);
-            return ResponseEntity.notFound().build();
-        }
-
-        try {
-            InputStreamResource resource = new InputStreamResource(new FileInputStream(file));
-            log.info("--- [SimSimInfo] exportDiary() 파일이 생성되었습니다 {}", filePath);
-
-            return ResponseEntity.ok()
-                    .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + file.getName() + "\"")
-                    .contentType(MediaType.parseMediaType("text/csv; charset=UTF-8"))
-                    .contentLength(file.length())
-                    .body(resource);
-        } catch (IOException e) {
-            log.error("--- [SimSimError] exportDiary() {} 파일 읽기에 실패했습니다", filePath, e);
-            throw e;
-        }
+        List<Map<String, Object>> diaryData = exportService.getDiaries(userId, filePath);
+        log.info("--- [SimSimInfo] 유저 {} 기록 Export 완료 (CSV 파일: {})", userId, filePath);
+        return ResponseEntity.ok(diaryData);
     }
 
     @GetMapping("/report")
-    public ResponseEntity<Resource> exportReport() throws IOException {
+    public ResponseEntity<List<Map<String, Object>>> exportReport() throws IOException {
         Long userId = authenticationService.getUserIdFromAuthentication();
         log.info("---[SimSimInfo] 유저 {} AI 응답 Export 요청 시작", userId);
 
@@ -70,25 +55,8 @@ public class ExportController {
         String directory = System.getProperty("java.io.tmpdir"); // 안전한 임시 디렉토리 사용
         String filePath = directory + File.separator + fileName;
 
-        exportService.getReponses(userId, filePath);
-        File file = new File(filePath);
-        if (!file.exists()) {
-            log.error("--- [SimSimError] exportResponses() 해당 파일이 존재하지 않습니다 {}", filePath);
-            return ResponseEntity.notFound().build();
-        }
-
-        try {
-            InputStreamResource resource = new InputStreamResource(new FileInputStream(file));
-            log.info("--- [SimSimInfo] exportResponses() 파일이 생성되었습니다 {}", filePath);
-
-            return ResponseEntity.ok()
-                    .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + file.getName() + "\"")
-                    .contentType(MediaType.parseMediaType("text/csv; charset=UTF-8"))
-                    .contentLength(file.length())
-                    .body(resource);
-        } catch (IOException e) {
-            log.error("--- [SimSimError] exportResponses() {} 파일 읽기에 실패했습니다", filePath, e);
-            throw e;
-        }
+        List<Map<String, Object>> responsesData = exportService.getReponses(userId, filePath);
+        log.info("--- [SimSimInfo] 유저 {} 편지 Export 완료 (CSV 파일: {})", userId, filePath);
+        return ResponseEntity.ok(responsesData);
     }
 }

--- a/src/main/java/com/project/simsim_server/controller/admin/ExportController.java
+++ b/src/main/java/com/project/simsim_server/controller/admin/ExportController.java
@@ -42,13 +42,13 @@ public class ExportController {
         exportService.getDiaries(userId, filePath);
         File file = new File(filePath);
         if (!file.exists()) {
-            log.error("File not found: {}", filePath);
+            log.error("--- [SimSimError] exportDiary() 해당 파일이 존재하지 않습니다 {}", filePath);
             return ResponseEntity.notFound().build();
         }
 
         try {
             InputStreamResource resource = new InputStreamResource(new FileInputStream(file));
-            log.info("File successfully created and ready for download: {}", filePath);
+            log.info("--- [SimSimInfo] exportDiary() 파일이 생성되었습니다 {}", filePath);
 
             return ResponseEntity.ok()
                     .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + file.getName() + "\"")
@@ -56,7 +56,38 @@ public class ExportController {
                     .contentLength(file.length())
                     .body(resource);
         } catch (IOException e) {
-            log.error("Error reading file: {}", filePath, e);
+            log.error("--- [SimSimError] exportDiary() {} 파일 읽기에 실패했습니다", filePath, e);
+            throw e;
+        }
+    }
+
+    @GetMapping("/report")
+    public ResponseEntity<Resource> exportReport() throws IOException {
+        Long userId = authenticationService.getUserIdFromAuthentication();
+        log.info("---[SimSimInfo] 유저 {} AI 응답 Export 요청 시작", userId);
+
+        String fileName = "response_export_" + LocalDate.now() + ".csv";
+        String directory = System.getProperty("java.io.tmpdir"); // 안전한 임시 디렉토리 사용
+        String filePath = directory + File.separator + fileName;
+
+        exportService.getReponses(userId, filePath);
+        File file = new File(filePath);
+        if (!file.exists()) {
+            log.error("--- [SimSimError] exportResponses() 해당 파일이 존재하지 않습니다 {}", filePath);
+            return ResponseEntity.notFound().build();
+        }
+
+        try {
+            InputStreamResource resource = new InputStreamResource(new FileInputStream(file));
+            log.info("--- [SimSimInfo] exportResponses() 파일이 생성되었습니다 {}", filePath);
+
+            return ResponseEntity.ok()
+                    .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + file.getName() + "\"")
+                    .contentType(MediaType.parseMediaType("text/csv; charset=UTF-8"))
+                    .contentLength(file.length())
+                    .body(resource);
+        } catch (IOException e) {
+            log.error("--- [SimSimError] exportResponses() {} 파일 읽기에 실패했습니다", filePath, e);
             throw e;
         }
     }

--- a/src/main/java/com/project/simsim_server/controller/admin/ExportController.java
+++ b/src/main/java/com/project/simsim_server/controller/admin/ExportController.java
@@ -1,0 +1,46 @@
+package com.project.simsim_server.controller.admin;
+
+import com.project.simsim_server.config.auth.jwt.AuthenticationService;
+import com.project.simsim_server.service.admin.ExportService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.time.LocalDate;
+
+
+@Tag(name = "Export", description = "관리자 서비스")
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/export")
+public class ExportController {
+
+    private final ExportService exportService;
+    private final AuthenticationService authenticationService;
+
+    @GetMapping("/diary")
+    public ResponseEntity<Resource> exportDiary() throws IOException {
+        Long userId = authenticationService.getUserIdFromAuthentication();
+        String fileName = "diary_export_" + LocalDate.now() + ".csv";
+        exportService.getDiaries(userId, fileName);
+
+        File file = new File(fileName);
+        InputStreamResource resource = new InputStreamResource(new FileInputStream(file));
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + file.getName())
+                .contentLength(file.length())
+                .contentType(MediaType.parseMediaType("text/csv"))
+                .body(resource);
+    }
+}

--- a/src/main/java/com/project/simsim_server/controller/admin/ExportController.java
+++ b/src/main/java/com/project/simsim_server/controller/admin/ExportController.java
@@ -33,6 +33,7 @@ public class ExportController {
     @GetMapping("/diary")
     public ResponseEntity<Resource> exportDiary() throws IOException {
         Long userId = authenticationService.getUserIdFromAuthentication();
+        log.info("---[SimSimInfo] 유저 {} 일기 Export 요청 시작", userId);
 
         String fileName = "diary_export_" + LocalDate.now() + ".csv";
         String directory = System.getProperty("java.io.tmpdir"); // 안전한 임시 디렉토리 사용

--- a/src/main/java/com/project/simsim_server/service/admin/ExportService.java
+++ b/src/main/java/com/project/simsim_server/service/admin/ExportService.java
@@ -1,7 +1,10 @@
 package com.project.simsim_server.service.admin;
 
 import com.project.simsim_server.domain.diary.Diary;
+import com.project.simsim_server.domain.user.Role;
+import com.project.simsim_server.domain.user.Users;
 import com.project.simsim_server.repository.diary.DiaryRepository;
+import com.project.simsim_server.repository.user.UsersRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,11 +18,16 @@ import java.util.List;
 @Service
 public class ExportService {
 
+    private final UsersRepository usersRepository;
     private final DiaryRepository diaryRepository;
 
     public void getDiaries(Long userId, String fileName) throws IOException {
 
-        //if (userId) {}
+        Users user = usersRepository.findById(userId).orElseThrow(() -> new RuntimeException("해당 회원이 존재하지 않습니다."));
+
+        if (user.getRole() != Role.ADMIN) {
+            throw new RuntimeException("해당 유저는 접근할 수 없습니다.");
+        }
 
         List<Diary> allDiaries = diaryRepository.findAll();
 

--- a/src/main/java/com/project/simsim_server/service/admin/ExportService.java
+++ b/src/main/java/com/project/simsim_server/service/admin/ExportService.java
@@ -1,0 +1,46 @@
+package com.project.simsim_server.service.admin;
+
+import com.project.simsim_server.domain.diary.Diary;
+import com.project.simsim_server.repository.diary.DiaryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class ExportService {
+
+    private final DiaryRepository diaryRepository;
+
+    public void getDiaries(Long userId, String fileName) throws IOException {
+
+        //if (userId) {}
+
+        List<Diary> allDiaries = diaryRepository.findAll();
+
+        try (FileWriter writer = new FileWriter(fileName)) {
+
+            writer.append("diary_id,user_id,diary_content,diary_list_key,diary_delete_yn,marked_date,created_date,modified_date,is_send_able\n");
+
+            for (Diary diary : allDiaries) {
+                writer.append(String.format(
+                        "%d,%d,\"%s\",%s,%s,%s,%s,%s,%s\n",
+                        diary.getDiaryId(),
+                        diary.getUserId(),
+                        diary.getContent(),
+                        diary.getListKey(),
+                        diary.getDiaryDeleteYn(),
+                        diary.getMarkedDate(),
+                        diary.getCreatedDate(),
+                        diary.getModifiedDate(),
+                        diary.getSendAble()
+                ));
+            }
+        }
+    }
+}

--- a/src/main/java/com/project/simsim_server/service/admin/ExportService.java
+++ b/src/main/java/com/project/simsim_server/service/admin/ExportService.java
@@ -8,16 +8,12 @@ import com.project.simsim_server.repository.ai.DailyAiInfoRepository;
 import com.project.simsim_server.repository.diary.DiaryRepository;
 import com.project.simsim_server.repository.user.UsersRepository;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.io.FileWriter;
-import java.io.IOException;
 import java.util.*;
 import java.util.stream.Collectors;
 
-@Slf4j
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 @Service
@@ -34,25 +30,6 @@ public class ExportService {
         }
 
         List<Diary> allDiaries = diaryRepository.findAll();
-        try (FileWriter writer = new FileWriter(fileName)) {
-            writer.append("diary_id,user_id,diary_content,diary_list_key,diary_delete_yn,marked_date,created_date,modified_date,is_send_able\n");
-            for (Diary diary : allDiaries) {
-                writer.append(String.format(
-                        "%d,%d,\"%s\",%s,%s,%s,%s,%s,%s\n",
-                        diary.getDiaryId(),
-                        diary.getUserId(),
-                        diary.getContent(),
-                        diary.getListKey(),
-                        diary.getDiaryDeleteYn(),
-                        diary.getMarkedDate(),
-                        diary.getCreatedDate(),
-                        diary.getModifiedDate(),
-                        diary.getSendAble()
-                ));
-            }
-        } catch (IOException e) {
-            log.error("--- [SimSimError] 기록 CSV 파일 생성 실패: {}", fileName, e);
-        }
 
         return allDiaries.stream().map((diary -> {
             Map<String, Object> diaryMap = new LinkedHashMap<>();
@@ -76,24 +53,6 @@ public class ExportService {
         }
 
         List<DailyAiInfo> responses = dailyAiInfoRepository.findAll();
-        try (FileWriter writer = new FileWriter(fileName)) {
-            writer.append("ai_id,user_id,ai_target_date,ai_diary_summary,ai_reply_content,ai_reply_status,created_date,modified_date\n");
-            for (DailyAiInfo reponse : responses) {
-                writer.append(String.format(
-                        "%d,%d,%s,\"%s\",\"%s\",%s,%s,%s\n",
-                        reponse.getAiId(),
-                        reponse.getUserId(),
-                        reponse.getTargetDate(),
-                        reponse.getDiarySummary().replace("\"", "\"\""),
-                        reponse.getReplyContent().replace("\"", "\"\""),
-                        reponse.getReplyStatus(),
-                        reponse.getCreatedDate(),
-                        reponse.getModifiedDate()
-                ));
-            }
-        } catch (IOException e) {
-            log.error("--- [SimSimError] 편지 CSV 파일 생성 실패: {}", fileName, e);
-        }
 
         return responses.stream().map((response) -> {
             Map<String, Object> responseMap = new LinkedHashMap<>();

--- a/src/main/java/com/project/simsim_server/service/admin/ExportService.java
+++ b/src/main/java/com/project/simsim_server/service/admin/ExportService.java
@@ -62,7 +62,7 @@ public class ExportService {
             writer.append("ai_id,user_id,ai_target_date,ai_diary_summary,ai_reply_content,ai_reply_status,created_date,modified_date\n");
             for (DailyAiInfo reponse : responses) {
                 writer.append(String.format(
-                        "%d,%d,%s,%s,%s,%s,%s,%s\n",
+                        "%d,%d,%s,\"%s\",\"%s\",%s,%s,%s\n",
                         reponse.getAiId(),
                         reponse.getUserId(),
                         reponse.getTargetDate(),

--- a/src/main/java/com/project/simsim_server/service/admin/ExportService.java
+++ b/src/main/java/com/project/simsim_server/service/admin/ExportService.java
@@ -1,8 +1,10 @@
 package com.project.simsim_server.service.admin;
 
+import com.project.simsim_server.domain.ai.DailyAiInfo;
 import com.project.simsim_server.domain.diary.Diary;
 import com.project.simsim_server.domain.user.Role;
 import com.project.simsim_server.domain.user.Users;
+import com.project.simsim_server.repository.ai.DailyAiInfoRepository;
 import com.project.simsim_server.repository.diary.DiaryRepository;
 import com.project.simsim_server.repository.user.UsersRepository;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.io.FileWriter;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -20,21 +23,17 @@ public class ExportService {
 
     private final UsersRepository usersRepository;
     private final DiaryRepository diaryRepository;
+    private final DailyAiInfoRepository dailyAiInfoRepository;
 
     public void getDiaries(Long userId, String fileName) throws IOException {
-
         Users user = usersRepository.findById(userId).orElseThrow(() -> new RuntimeException("해당 회원이 존재하지 않습니다."));
-
         if (user.getRole() != Role.ADMIN) {
             throw new RuntimeException("해당 유저는 접근할 수 없습니다.");
         }
 
         List<Diary> allDiaries = diaryRepository.findAll();
-
         try (FileWriter writer = new FileWriter(fileName)) {
-
             writer.append("diary_id,user_id,diary_content,diary_list_key,diary_delete_yn,marked_date,created_date,modified_date,is_send_able\n");
-
             for (Diary diary : allDiaries) {
                 writer.append(String.format(
                         "%d,%d,\"%s\",%s,%s,%s,%s,%s,%s\n",
@@ -47,6 +46,31 @@ public class ExportService {
                         diary.getCreatedDate(),
                         diary.getModifiedDate(),
                         diary.getSendAble()
+                ));
+            }
+        }
+    }
+
+    public void getReponses(Long userId, String fileName) throws IOException {
+        Users user = usersRepository.findById(userId).orElseThrow(() -> new RuntimeException("해당 회원이 존재하지 않습니다."));
+        if (user.getRole() != Role.ADMIN) {
+            throw new RuntimeException("해당 유저는 접근할 수 없습니다.");
+        }
+
+        List<DailyAiInfo> responses = dailyAiInfoRepository.findAll();
+        try (FileWriter writer = new FileWriter(fileName)) {
+            writer.append("ai_id,user_id,ai_target_date,ai_diary_summary,ai_reply_content,ai_reply_status,created_date,modified_date\n");
+            for (DailyAiInfo reponse : responses) {
+                writer.append(String.format(
+                        "%d,%d,\"%s\",%s,%s,%s,%s,%s,%s\n",
+                        reponse.getAiId(),
+                        reponse.getUserId(),
+                        reponse.getTargetDate(),
+                        reponse.getDiarySummary(),
+                        reponse.getReplyContent(),
+                        reponse.getReplyStatus(),
+                        reponse.getCreatedDate(),
+                        reponse.getModifiedDate()
                 ));
             }
         }

--- a/src/main/java/com/project/simsim_server/service/admin/ExportService.java
+++ b/src/main/java/com/project/simsim_server/service/admin/ExportService.java
@@ -66,8 +66,8 @@ public class ExportService {
                         reponse.getAiId(),
                         reponse.getUserId(),
                         reponse.getTargetDate(),
-                        reponse.getDiarySummary(),
-                        reponse.getReplyContent(),
+                        reponse.getDiarySummary().replace("\"", "\"\""),
+                        reponse.getReplyContent().replace("\"", "\"\""),
                         reponse.getReplyStatus(),
                         reponse.getCreatedDate(),
                         reponse.getModifiedDate()

--- a/src/main/java/com/project/simsim_server/service/admin/ExportService.java
+++ b/src/main/java/com/project/simsim_server/service/admin/ExportService.java
@@ -62,7 +62,7 @@ public class ExportService {
             writer.append("ai_id,user_id,ai_target_date,ai_diary_summary,ai_reply_content,ai_reply_status,created_date,modified_date\n");
             for (DailyAiInfo reponse : responses) {
                 writer.append(String.format(
-                        "%d,%d,\"%s\",%s,%s,%s,%s,%s,%s\n",
+                        "%d,%d,%s,%s,%s,%s,%s,%s\n",
                         reponse.getAiId(),
                         reponse.getUserId(),
                         reponse.getTargetDate(),

--- a/src/main/java/com/project/simsim_server/service/admin/ExportService.java
+++ b/src/main/java/com/project/simsim_server/service/admin/ExportService.java
@@ -27,7 +27,7 @@ public class ExportService {
     private final DiaryRepository diaryRepository;
     private final DailyAiInfoRepository dailyAiInfoRepository;
 
-    public List<Map<String, Object>> getDiaries(Long userId, String fileName) throws IOException {
+    public List<Map<String, Object>> getDiaries(Long userId, String fileName) {
         Users user = usersRepository.findById(userId).orElseThrow(() -> new RuntimeException("해당 회원이 존재하지 않습니다."));
         if (user.getRole() != Role.ADMIN) {
             throw new RuntimeException("해당 유저는 접근할 수 없습니다.");
@@ -69,7 +69,7 @@ public class ExportService {
         })).collect(Collectors.toList());
     }
 
-    public List<Map<String, Object>> getReponses(Long userId, String fileName) throws IOException {
+    public List<Map<String, Object>> getReponses(Long userId, String fileName) {
         Users user = usersRepository.findById(userId).orElseThrow(() -> new RuntimeException("해당 회원이 존재하지 않습니다."));
         if (user.getRole() != Role.ADMIN) {
             throw new RuntimeException("해당 유저는 접근할 수 없습니다.");
@@ -98,14 +98,22 @@ public class ExportService {
         return responses.stream().map((response) -> {
             Map<String, Object> responseMap = new LinkedHashMap<>();
             responseMap.put("ai_id", response.getAiId());
-            responseMap.put("user_id", user.getUserId());
+            responseMap.put("user_id", response.getUserId());
             responseMap.put("ai_target_date", response.getTargetDate());
-            responseMap.put("ai_diary_summary", response.getDiarySummary());
-            responseMap.put("ai_reply_content", response.getReplyContent());
+            responseMap.put("ai_diary_summary", escapeJson(response.getDiarySummary()));
+            responseMap.put("ai_reply_content", escapeJson(response.getReplyContent()));
             responseMap.put("ai_reply_status", response.getReplyStatus());
             responseMap.put("created_date", response.getCreatedDate());
             responseMap.put("modified_date", response.getModifiedDate());
             return responseMap;
         }).collect(Collectors.toList());
     }
+
+    private String escapeJson(String value) {
+        if (value == null) {
+            return null;
+        }
+        return value.replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t");
+    }
+
 }


### PR DESCRIPTION
### Summary
1. 관리자 계정에서 설정 메뉴에 '기록 가져오기' 클릭 시 모든 기록 csv 파일로 다운로드하는 API 구현
2. 관리자 계정에서 설정 메뉴에 '편지 가져오기' 클릭 시 모든 기록 csv 파일로 다운로드하는 API 구현

### Description
- 기획자의 요청에 대해 상기 2가지 API 구현

### To Do
- 관리자 페이지 구현 시, API URL 변경
- Report API 구현 후, '편지 가져오기'의 응답에 해당 내용을 추가