### PR TITLE
[Feat] Implement monthly report api

### DIFF
--- a/src/main/java/com/project/simsim_server/controller/ai/ReportController.java
+++ b/src/main/java/com/project/simsim_server/controller/ai/ReportController.java
@@ -2,12 +2,14 @@ package com.project.simsim_server.controller.ai;
 
 import com.project.simsim_server.config.auth.jwt.AuthenticationService;
 
+import com.project.simsim_server.dto.ai.client.AIMonthlyResponseDTO;
 import com.project.simsim_server.service.report.ReportService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Tag(name = "Report", description = "레포트 서비스")
 @RequiredArgsConstructor
@@ -17,4 +19,17 @@ public class ReportController {
 
     private final ReportService reportService;
     private final AuthenticationService authenticationService;
+
+    /**
+     * 월간 키워드 정보 조회
+     * @param targetDate year + month ex) 202503
+     * @return AIMonthlyResponseDTO 리스트 (rate, keyword, comment)
+     */
+    @GetMapping("/montly/{targetDate}")
+    public List<AIMonthlyResponseDTO> getAIMontlyReport(
+            @PathVariable String targetDate
+    ) {
+        Long userId = authenticationService.getUserIdFromAuthentication();
+        return reportService.findByuserIdAndTargetDate(userId, targetDate);
+    }
 }

--- a/src/main/java/com/project/simsim_server/dto/ai/client/AILetterResponseDTO.java
+++ b/src/main/java/com/project/simsim_server/dto/ai/client/AILetterResponseDTO.java
@@ -14,7 +14,6 @@ import java.time.LocalDate;
 @NoArgsConstructor
 public class AILetterResponseDTO {
     private Long aiId;
-
     private Long reportId;
     private LocalDate date;
     private String summary;

--- a/src/main/java/com/project/simsim_server/dto/ai/client/AIMonthlyResponseDTO.java
+++ b/src/main/java/com/project/simsim_server/dto/ai/client/AIMonthlyResponseDTO.java
@@ -1,0 +1,49 @@
+package com.project.simsim_server.dto.ai.client;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.simsim_server.domain.ai.MonthlyReport;
+import com.project.simsim_server.exception.ai.AIException;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Getter
+@NoArgsConstructor
+public class AIMonthlyResponseDTO {
+    private Double rate;
+    private String keyword;
+    private String comment;
+
+    public AIMonthlyResponseDTO(String keyword, Double rate) {
+        this.rate = rate;
+        this.keyword = keyword;
+        this.comment = generateComment(keyword, rate);
+    }
+
+    private String generateComment(String keyword, Double rate) {
+        int ratePercentage = (int) Math.floor(rate);
+        return keyword + "의 비율은 " + ratePercentage + "% 입니다.";
+    }
+
+    public static List<AIMonthlyResponseDTO> convertFromJSONtoObject(String jsonData) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            Map<String, Double> dataMap = objectMapper.readValue(jsonData,
+                    new TypeReference<Map<String, Double>>() {});
+            return dataMap.entrySet().stream()
+                    .map(keywordSet -> new AIMonthlyResponseDTO(keywordSet.getKey(), keywordSet.getValue()))
+                    .sorted(Comparator.comparing(AIMonthlyResponseDTO::getRate).reversed())
+                    .collect(Collectors.toList());
+        } catch (Exception e) {
+            log.error("---[SimSimError] AI 월간 레포트 JSON 파싱 에러---");
+            throw new RuntimeException("AI 키워드 JSON 파싱 실패");
+        }
+    }
+}

--- a/src/main/java/com/project/simsim_server/exception/ErrorType.java
+++ b/src/main/java/com/project/simsim_server/exception/ErrorType.java
@@ -2,6 +2,5 @@ package com.project.simsim_server.exception;
 
 public interface ErrorType {
     String getMessage();
-
     int getCode();
 }

--- a/src/main/java/com/project/simsim_server/exception/ai/AIErrorCode.java
+++ b/src/main/java/com/project/simsim_server/exception/ai/AIErrorCode.java
@@ -4,13 +4,12 @@ import com.project.simsim_server.exception.ErrorType;
 
 public enum AIErrorCode implements ErrorType {
 
-    NO_DIARIES("분석할 일기가 없습니다", 404),
-    REPORT_NOT_FOUND("분석 결과가 존재하지 않습니다", 404),
+    NO_DIARIES("분석할 일기가 없습니다.", 404),
+    REPORT_NOT_FOUND("분석 결과가 존재하지 않습니다.", 404),
     AILETTERS_NOT_FOUND("AI 편지가 존재하지 않습니다.", 404),
     AIRESPONE_NOT_FOUND("AI 응답이 존재하지 않습니다.", 404),
-    EMOTION_NOT_FOUND("해당 기간동안 분석된 감정 결과가 없습니다.", 404),
     AI_MAIL_FAIL("AI 편지 생성이 실패했습니다.", 404),
-    AI_NOT_INVALID_DATE("AI를 생성할 수 없는 날짜입니다.", 400),
+    AI_NOT_INVALID_DATE("AI 응답을 생성할 수 없는 날짜입니다.", 400),
     NOT_MEET_USER_GRADE("현재 등급으로 조회할 수 없습니다. 내일 다시 시도해주세요.", 403);
 
     private final String message;

--- a/src/main/java/com/project/simsim_server/service/report/ReportService.java
+++ b/src/main/java/com/project/simsim_server/service/report/ReportService.java
@@ -1,25 +1,18 @@
 package com.project.simsim_server.service.report;
 
 
-import com.project.simsim_server.domain.ai.DailyAiInfo;
-import com.project.simsim_server.domain.diary.Diary;
-import com.project.simsim_server.dto.ai.client.AnalyzeMaxInfoDTO;
-import com.project.simsim_server.dto.ai.client.WeekEmotionsResponseDTO;
-import com.project.simsim_server.dto.ai.client.WeekSummaryResponseDTO;
+import com.project.simsim_server.domain.ai.MonthlyReport;
+import com.project.simsim_server.dto.ai.client.AIMonthlyResponseDTO;
 import com.project.simsim_server.exception.ai.AIException;
-import com.project.simsim_server.repository.ai.DailyAiInfoRepository;
-import com.project.simsim_server.repository.diary.DiaryRepository;
+import com.project.simsim_server.repository.ai.MonthlyReportRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.Year;
+import java.time.*;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
-import java.util.Optional;
 
 import static com.project.simsim_server.exception.ai.AIErrorCode.*;
 
@@ -29,6 +22,40 @@ import static com.project.simsim_server.exception.ai.AIErrorCode.*;
 @Service
 public class ReportService {
 
-    private final DiaryRepository diaryRepository;
-    private final DailyAiInfoRepository dailyAiInfoRepository;
+    private final MonthlyReportRepository monthlyReportRepository;
+
+    public List<AIMonthlyResponseDTO> findByuserIdAndTargetDate(
+            Long userId, String targetDate
+    ) {
+        if (isFuturDay(targetDate)) {
+            throw new AIException(AI_NOT_INVALID_DATE);
+        }
+        int targetYear = Integer.parseInt(targetDate.substring(0, 4));
+        int targetMonth = Integer.parseInt(targetDate.substring(4, 6));
+        log.info("---[SimSimInfo] 월간 레포트 targetYear : {}, targetMonth : {}", targetYear, targetMonth);
+
+        List<MonthlyReport> monthlyReportList
+                = monthlyReportRepository.findByIdAndTargetDate(userId, targetYear, targetMonth);
+        if (monthlyReportList.isEmpty()) {
+            throw new AIException(REPORT_NOT_FOUND);
+        }
+        String jsonData = monthlyReportList.getFirst().getKeywordsData();
+        List<AIMonthlyResponseDTO> responseList = AIMonthlyResponseDTO.convertFromJSONtoObject(jsonData);
+        if (responseList.isEmpty()) {
+            throw new AIException(REPORT_NOT_FOUND);
+        }
+
+        //TODO - 추후 삭제
+        for(AIMonthlyResponseDTO responseDTO : responseList) {
+            log.info("---[SimSimInfo] keyword={}, rate={}, comment={}",
+                    responseDTO.getKeyword(), responseDTO.getRate(), responseDTO.getComment());
+        }
+        return responseList;
+    }
+
+    private Boolean isFuturDay(String targetDate) {
+        YearMonth targetYearMonth = YearMonth.parse(targetDate, DateTimeFormatter.ofPattern("yyyyMM"));
+        YearMonth currentYearMonth = YearMonth.now();
+        return targetYearMonth.isAfter(currentYearMonth);
+    }
 }

--- a/src/test/java/com/project/simsim_server/service/report/ReportServiceTest.java
+++ b/src/test/java/com/project/simsim_server/service/report/ReportServiceTest.java
@@ -1,43 +1,86 @@
-//package com.project.simsim_server.service.report;
-//
-//import com.project.simsim_server.domain.diary.Diary;
-//import com.project.simsim_server.dto.ai.client.WeekSummaryResponseDTO;
-//import com.project.simsim_server.repository.diary.DiaryRepository;
-//import org.junit.jupiter.api.Test;
-//import org.springframework.beans.factory.annotation.Autowired;
-//import org.springframework.boot.test.context.SpringBootTest;
-//
-//import java.time.LocalDate;
-//import java.time.LocalDateTime;
-//import java.time.LocalTime;
-//import java.util.List;
-//
-//import static org.assertj.core.api.Assertions.*;
-//
-//@SpringBootTest
-//class ReportServiceTest {
-//
-//    @Autowired
-//    private ReportService reportService;
-//
-//    @Autowired
-//    private DiaryRepository diaryRepository;
-//
-//    @Test
-//    void N번요약결과_확인() {
-//        // given
-//        Long userId = 1L;
-//        LocalDate today = LocalDate.now();
-//        LocalDateTime startDate = LocalDate.of(2024, 1, 1).atStartOfDay();
-//        LocalDateTime endDate = today.atTime(LocalTime.now());
-//
-//        // when
-//        WeekSummaryResponseDTO results = reportService.weekReportSummary(userId, today);
-//        List<Diary> diaries = diaryRepository.findDiariesByCreatedAtBetweenAndUserId(startDate, endDate, userId);
-//
-//        // then
-//        assertThat(results).isNotNull();
-//        assertThat(diaries).isNotNull();
-//        assertThat(diaries.size()).isEqualTo(results.getDiaryCnt());
-//    }
-//}
+package com.project.simsim_server.service.report;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.simsim_server.domain.ai.MonthlyReport;
+import com.project.simsim_server.domain.diary.Diary;
+import com.project.simsim_server.dto.ai.client.AIMonthlyResponseDTO;
+import com.project.simsim_server.dto.ai.client.WeekSummaryResponseDTO;
+import com.project.simsim_server.exception.ai.AIErrorCode;
+import com.project.simsim_server.exception.ai.AIException;
+import com.project.simsim_server.repository.ai.MonthlyReportRepository;
+import com.project.simsim_server.repository.diary.DiaryRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+class ReportServiceTest {
+
+    @Autowired
+    private ReportService reportService;
+
+    @Autowired
+    private MonthlyReportRepository monthlyReportRepository;
+
+    private final Long TEST_USER_ID = 1L;
+
+    @Test
+    void 월간레포트_확인() {
+        // given
+        String targetDate = YearMonth.now().format(DateTimeFormatter.ofPattern("yyyyMM"));
+
+        // when
+        List<AIMonthlyResponseDTO> reponseList = reportService.findByuserIdAndTargetDate(TEST_USER_ID, targetDate);
+
+        // then
+        assertThat(reponseList).isNotNull();
+        assertThat(reponseList.get(0).getKeyword()).isEqualTo("카공");
+        assertThat(reponseList.get(0).getRate()).isEqualTo(3.0867);
+        assertThat(reponseList.get(0).getComment()).isEqualTo("카공의 비율은 3% 입니다.");
+    }
+
+    @Test
+    void 월간레포트_미래날짜_확인() {
+        // given
+        String targetDate = YearMonth.of(2026, 2).format(DateTimeFormatter.ofPattern("yyyyMM"));
+
+        // when & then
+        assertThatThrownBy(() -> reportService.findByuserIdAndTargetDate(TEST_USER_ID, targetDate))
+                .isInstanceOf(AIException.class)
+                .extracting(ex -> (AIException) ex)
+                .extracting(AIException::getErrorType)
+                .isInstanceOf(AIErrorCode.class)
+                .satisfies(errorType -> {
+                    AIErrorCode aiErrorCode = (AIErrorCode) errorType;
+                    assertThat(aiErrorCode.getMessage()).isEqualTo(AIErrorCode.AI_NOT_INVALID_DATE.getMessage());
+                    assertThat(aiErrorCode.getCode()).isEqualTo(AIErrorCode.AI_NOT_INVALID_DATE.getCode());
+                });
+    }
+
+    @Test
+    void 월간레포트_기록이없는월_확인() {
+        // given
+        String targetDate = YearMonth.of(2025, 1).format(DateTimeFormatter.ofPattern("yyyyMM"));
+
+        // when & then
+        assertThatThrownBy(() -> reportService.findByuserIdAndTargetDate(TEST_USER_ID, targetDate))
+                .isInstanceOf(AIException.class)
+                .extracting(ex -> (AIException) ex) // AIException으로 추출
+                .extracting(AIException::getErrorType) // getErrorType() 호출로 AIErrorCode 추출
+                .isInstanceOf(AIErrorCode.class) // AIErrorCode 타입인지 확인
+                .satisfies(errorType -> {
+                    AIErrorCode aiErrorCode = (AIErrorCode) errorType;
+                    assertThat(aiErrorCode.getMessage()).isEqualTo(AIErrorCode.REPORT_NOT_FOUND.getMessage());
+                    assertThat(aiErrorCode.getCode()).isEqualTo(AIErrorCode.REPORT_NOT_FOUND.getCode());
+                });
+    }
+}


### PR DESCRIPTION
###Summary
- 월간 레포트 API 생성

###Description
- 기존의 주간 레포트 API 제거
- 금일의 해당 월 1일~금일까지의 Keyword, rate, comment 정보 응답 API 생성
- 비율이 높음 -> 낮음 순으로 정렬 